### PR TITLE
chore: let Dependabot open up to 10 PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
I find it mildly annoying to have to manually pull in more updates every 5 PRs.