### PR TITLE
feat: support header-value override env vars

### DIFF
--- a/lib/delta/producer.ex
+++ b/lib/delta/producer.ex
@@ -31,7 +31,7 @@ defmodule Delta.Producer do
     frequency = Keyword.get(opts, :frequency, @default_frequency)
     http_mod = Keyword.get(opts, :http_mod, @default_http_mod)
     filters = Keyword.get(opts, :filters, Filter.default_filters())
-    headers = Keyword.get(opts, :headers, [])
+    headers = Keyword.get(opts, :headers, %{})
     {:ok, conn} = http_mod.new(url, headers: Enum.to_list(headers))
 
     state = %__MODULE__{

--- a/test/delta/application_test.exs
+++ b/test/delta/application_test.exs
@@ -21,6 +21,39 @@ defmodule Delta.ApplicationTest do
       assert ^expected = Application.config([{:system, env_var}])
     end
 
+    test "can get header secrets from the environment" do
+      secure_env_var = "SOME_SECURE_ENV_VAR"
+      secure_value = "SOME_SUPER_SECURE_VALUE"
+      System.put_env(secure_env_var, secure_value)
+
+      expected = %{
+        "producers" => %{
+          "test" => %{
+            "headers" => %{
+              "SOME_HEADER" => "SOME_SUPER_SECURE_VALUE"
+            }
+          }
+        },
+        "sinks" => %{"log" => %{"type" => "log"}}
+      }
+
+      substituted = %{
+        "producers" => %{
+          "test" => %{
+            "headers" => %{
+              "SOME_HEADER" => %{"system" => secure_env_var}
+            }
+          }
+        },
+        "sinks" => %{"log" => %{"type" => "log"}}
+      }
+
+      env_var = "DELTA_APPLICATION_TEST"
+      json = Jason.encode!(substituted)
+      System.put_env(env_var, json)
+      assert ^expected = Application.config([{:system, env_var}])
+    end
+
     test "can get configurations from the environment, merged" do
       expected_first = %{"producers" => %{}, "sinks" => %{"log" => %{"type" => "log"}}}
       env_var_first = "DELTA_APPLICATION_TEST_1"


### PR DESCRIPTION
Adds the ability to specify header values as an arbitrary environment variable. 

For example, deploying the following config with the env var `SOME_SPECIFIC_ENV_VAR` set to `ABCD123`: 

```
{
  "producers": {
    "test": { 
      "headers": {
        "SOME_HEADER": {"system": "SOME_SPECIFIC_ENV_VAR"}
      }
    }
  }
}
```

Results in:

```
{
  "producers": {
    "test": { 
      "headers": {
        "SOME_HEADER": "ABCD123"
      }
    }
  }
}
```

This feature was inspired by https://github.com/mbta/concentrate/pull/99/files and is implemented to support https://github.com/mbta/devops/pull/1850