### PR TITLE
feat: allow for filename replacements in sink config

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.2
-elixir 1.14.2-otp-25
+erlang 25.3.2.12
+elixir 1.14.5-otp-25

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # From https://hub.docker.com/r/hexpm/elixir/tags
-FROM hexpm/elixir:1.14.2-erlang-25.2-alpine-3.17.0 AS builder
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.12-alpine-3.17.7 AS builder
 
 WORKDIR /root
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Configuration options:
 * `prefix`: Default `""`. Will prepend this to all file names it writes to s3.
 * `acl`: Default `"public-read"`. Passed to `S3.put_object`.
 * `producers`: Required list of string producer names.
+* `filename_rewrites`: Default `[]`. Contains a list of maps like - `%{pattern: "old_value", replacement: "new_value"}` - this will be applied to the resulting s3 filename. 
 
 ### Log
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Configuration options:
 * `prefix`: Default `""`. Will prepend this to all file names it writes to s3.
 * `acl`: Default `"public-read"`. Passed to `S3.put_object`.
 * `producers`: Required list of string producer names.
-* `filename_rewrites`: Default `[]`. Contains a list of maps like - `%{pattern: "old_value", replacement: "new_value"}` - this will be applied to the resulting s3 filename. 
+* `filename_rewrites`: Default `[]`. Contains a list of maps like - `%{pattern: "old_value", replacement: "new_value"}` - this will be applied to the resulting s3 filename. Note: the full collection gets applied to every resultant producer filename, so these configurations should be relatively specific. 
 
 ### Log
 

--- a/lib/delta/pipeline_supervisor.ex
+++ b/lib/delta/pipeline_supervisor.ex
@@ -85,7 +85,10 @@ defmodule Delta.PipelineSupervisor do
     {Delta.Sink.S3,
      bucket: Map.fetch!(config, "bucket"),
      prefix: Map.get(config, "prefix", ""),
-     acl: Map.get(config, "acl", "public-read")}
+     acl: Map.get(config, "acl", "public-read"),
+     filename_rewrites:
+       Map.get(config, "filename_rewrites", [])
+       |> Enum.map(fn x -> for {key, val} <- x, into: %{}, do: {String.to_atom(key), val} end)}
   end
 
   defp sink_type_opts(%{"type" => "log"}) do

--- a/lib/delta/sink/s3.ex
+++ b/lib/delta/sink/s3.ex
@@ -40,7 +40,7 @@ defmodule Delta.Sink.S3 do
       String.replace(modified_filename, rewrite.pattern, rewrite.replacement)
     end)
   end
-  
+
   defp apply_filename_rewrite(_config, filename), do: filename
 
   defp build_filename(%File{} = file) do

--- a/lib/delta/sink/s3.ex
+++ b/lib/delta/sink/s3.ex
@@ -35,19 +35,13 @@ defmodule Delta.Sink.S3 do
     end
   end
 
-  defp apply_filename_rewrite(config, filename) do
-    if Map.has_key?(config, :filename_rewrites) do
-      do_apply_filename_rewrite(config.filename_rewrites, filename)
-    else
-      filename
-    end
-  end
-
-  defp do_apply_filename_rewrite(rewrites, filename) do
+  defp apply_filename_rewrite(%{filename_rewrites: rewrites}, filename) do
     Enum.reduce(rewrites, filename, fn rewrite, modified_filename ->
       String.replace(modified_filename, rewrite.pattern, rewrite.replacement)
     end)
   end
+  
+  defp apply_filename_rewrite(_config, filename), do: filename
 
   defp build_filename(%File{} = file) do
     iso_dt = DateTime.to_iso8601(file.updated_at)


### PR DESCRIPTION
Adds a new S3 sink configuration option `filename_rewrites` which contains a value like - `[%{pattern: "old_value", replacement: "new_value"}]`. 

This can be used to modify any part of the S3 path, which can be useful for standardizing URL formats when requesting data from different environments (CDN vs non-CDN, RTR direct vs. Concentrate). 
